### PR TITLE
Fix: Ensure RPC mode aligns with public node setting

### DIFF
--- a/logic/disk.js
+++ b/logic/disk.js
@@ -147,15 +147,18 @@ function settingsToMultilineConfString(settings) {
   }
 
 
-  // umbrelMoneroConfig.push(`rpc-bind-ip=0.0.0.0`);
-  umbrelMoneroConfig.push(`rpc-restricted-bind-ip=0.0.0.0`);
-  // umbrelMoneroConfig.push(`rpc-bind-port=${constants.MONERO_RPC_PORT}`);
-  umbrelMoneroConfig.push(`rpc-restricted-bind-port=${constants.MONERO_RESTRICTED_RPC_PORT}`);
-
-  // Public Node
+  // Check if the node should be public or not
   if (settings.publicNode) {
     umbrelMoneroConfig.push('public-node=1');
     umbrelMoneroConfig.push(`confirm-external-bind=1`);
+
+    // Use restricted RPC mode when the node is public
+    umbrelMoneroConfig.push(`rpc-restricted-bind-ip=0.0.0.0`);
+    umbrelMoneroConfig.push(`rpc-restricted-bind-port=${constants.MONERO_RESTRICTED_RPC_PORT}`);
+  } else {
+    // Use unrestricted RPC mode when the node is private
+    umbrelMoneroConfig.push(`rpc-bind-ip=0.0.0.0`);
+    umbrelMoneroConfig.push(`rpc-bind-port=${constants.MONERO_RPC_PORT}`);
   }
 
   if (process.env.APP_BTCPAY_IP && process.env.APP_BTCPAY_PORT) {
@@ -170,7 +173,7 @@ function settingsToMultilineConfString(settings) {
 export async function getJsonStore() {
   try {
     const jsonStore = await diskService.readJsonFile(constants.JSON_STORE_FILE);
-    return {...DEFAULT_ADVANCED_SETTINGS, ...jsonStore};
+    return { ...DEFAULT_ADVANCED_SETTINGS, ...jsonStore };
   } catch (error) {
     return DEFAULT_ADVANCED_SETTINGS;
   }


### PR DESCRIPTION
#### Summary:  
This PR fixes an issue where the Monero node was always running in restricted RPC mode, even when `publicNode` was set to `false`. Now, the node correctly:  
- Runs in **restricted RPC mode** when `publicNode` is `true`.  
- Runs in **unrestricted RPC mode** when `publicNode` is `false`.  

This change ensures that the node's RPC behavior is aligned with the advertised functionality of the PublicNode setting on the web interface.

#### Changes:  
- Added conditional logic to set `rpc-bind-ip` and `rpc-bind-port` only when `publicNode` is `false`.  
- Ensured `rpc-restricted-bind-ip` and `rpc-restricted-bind-port` are used only when `publicNode` is `true`.  

#### Testing:  
- Tested the configuration to verify that the correct RPC mode is applied based on the `publicNode` setting.  